### PR TITLE
add parameter_dict

### DIFF
--- a/classylss/binding.pyx
+++ b/classylss/binding.pyx
@@ -196,6 +196,18 @@ cdef class ClassEngine:
             lines = ["%s : %s" %(self.fc.name[i].decode(), self.fc.value[i].decode())
                for i in range(self.fc.size)]
             return "\n".join(lines)
+    property parameter_dict:
+        """
+        A dict holding the parameter names and values as loaded by CLASS.
+
+        This dictionary can be furthter modified to initialize classy.
+        """
+        def __get__(self):
+            if not self.ready.fc: return {}
+
+            lines = [(self.fc.name[i].decode(), self.fc.value[i].decode())
+               for i in range(self.fc.size)]
+            return dict(lines)
 
     def __cinit__(self, *args, **kwargs):
         memset(&self.ready, 0, sizeof(self.ready))

--- a/classylss/tests/test_binding.py
+++ b/classylss/tests/test_binding.py
@@ -64,7 +64,7 @@ def test_parameter_dict():
     if sys.version_info[0] >= 3:
         basestring = str
     else:
-        basestring = basestring
+        pass
 
     for key, value in d.items():
         assert isinstance(key, basestring)

--- a/classylss/tests/test_binding.py
+++ b/classylss/tests/test_binding.py
@@ -60,6 +60,12 @@ def test_parameter_dict():
     cosmo = ClassEngine({'N_ncdm': 1, 'm_ncdm':[0.06]})
     d = cosmo.parameter_dict
 
+    import sys
+    if sys.version_info[0] >= 3:
+        basestring = str
+    else:
+        basestring = basestring
+
     for key, value in d.items():
-        assert isinstance(key, str)
-        assert isinstance(value, str)
+        assert isinstance(key, basestring)
+        assert isinstance(value, basestring)

--- a/classylss/tests/test_binding.py
+++ b/classylss/tests/test_binding.py
@@ -56,15 +56,16 @@ def test_primordial(a_max):
 
     pr = pm.get_primordial()
 
+import sys
+if sys.version_info[0] >= 3:
+    basestring = str
+else:
+    pass
+
 def test_parameter_dict():
     cosmo = ClassEngine({'N_ncdm': 1, 'm_ncdm':[0.06]})
     d = cosmo.parameter_dict
 
-    import sys
-    if sys.version_info[0] >= 3:
-        basestring = str
-    else:
-        pass
 
     for key, value in d.items():
         assert isinstance(key, basestring)

--- a/classylss/tests/test_binding.py
+++ b/classylss/tests/test_binding.py
@@ -55,3 +55,11 @@ def test_primordial(a_max):
     Pk = pm.get_pkprim([0., 0.1, 0.2])
 
     pr = pm.get_primordial()
+
+def test_parameter_dict():
+    cosmo = ClassEngine({'N_ncdm': 1, 'm_ncdm':[0.06]})
+    d = cosmo.parameter_dict
+
+    for key, value in d.items():
+        assert isinstance(key, str)
+        assert isinstance(value, str)


### PR DESCRIPTION
parameter_dict can be used to populate classy. This is useful when one want to switch to the standard classy binding which has the Cl stuff.