### PR TITLE
Update classy to 2.6.3

### DIFF
--- a/classylss/tests/test_binding.py
+++ b/classylss/tests/test_binding.py
@@ -56,6 +56,12 @@ def test_primordial(a_max):
 
     pr = pm.get_primordial()
 
+def test_sigma8():
+
+    cosmo = ClassEngine({'sigma8': 0.8, 'output': 'dTk vTk mPk', 'P_k_max_h/Mpc' : 20., "z_max_pk" : 100.0})
+    sp = Spectra(cosmo)
+    assert abs(sp.sigma8 - 0.8) < 1e-4
+
 import sys
 if sys.version_info[0] >= 3:
     basestring = str

--- a/classylss/version.py
+++ b/classylss/version.py
@@ -1,2 +1,2 @@
 version = '0.2.9.dev0'
-class_version = '2.6.1'
+class_version = '2.6.3'

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -1,4 +1,4 @@
-CLASS_VERSION?=2.6.1
+CLASS_VERSION?=2.6.3
 DEST?=_inst
 
 TARBALL=class-v$(CLASS_VERSION).tar.gz
@@ -16,9 +16,11 @@ $(SRC)/stamp.unzip: $(TARBALL)
 
 $(SRC)/stamp.patch : $(SRC)/stamp.unzip \
 	  class-2.6.0-a_max.patch \
-	  class-2.6.0-tol-ncdm.patch
+	  class-2.6.0-tol-ncdm.patch \
+	  class-2.6.1-pathsize.patch
 	patch -d $(SRC) -p1 < class-2.6.0-a_max.patch || exit 1 
-	patch -d $(SRC) -p1 < class-2.6.0-tol-ncdm.patch || exit 1
+#	No longer needed after 2.6.3
+#	patch -d $(SRC) -p1 < class-2.6.0-tol-ncdm.patch || exit 1
 	patch -d $(SRC) -p1 < class-2.6.1-pathsize.patch || exit 1
 	touch $@
 


### PR DESCRIPTION
Mainly to support sigma8 as an input argument. It doesn't seem to be very accurate though.